### PR TITLE
Add extra packages to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM debian:buster
 
 RUN apt-get update &&\
-    apt-get install -y sudo time git-core subversion build-essential g++ bash make libssl-dev patch libncurses5 libncurses5-dev zlib1g-dev gawk flex gettext wget unzip xz-utils python python-distutils-extra python3 python3-distutils-extra rsync curl && \
+    apt-get install -y \
+        sudo time git-core subversion build-essential g++ bash make \
+        libssl-dev patch libncurses5 libncurses5-dev zlib1g-dev gawk \
+        flex gettext wget unzip xz-utils python python-distutils-extra \
+        python3 python3-distutils-extra rsync curl libsnmp-dev liblzma-dev \
+        libpam0g-dev cpio && \
     apt-get clean && \
     useradd -m user && \
     echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user


### PR DESCRIPTION
On the latest OpenWRT `master` branch, using this Docker container image, a few missing packages caused build warnings or failures, as follows.  This patch adds the missing packages, fixing the warnings & failures.

libsnmp-dev liblzma-dev libpam0g-dev:

    WARNING: Makefile 'package/utils/busybox/Makefile' has a dependency on 'libpam', which does not exist
    WARNING: Makefile 'package/utils/busybox/Makefile' has a dependency on 'libpam', which does not exist
    WARNING: Makefile 'package/utils/busybox/Makefile' has a build dependency on 'libpam', which does not exist
    WARNING: Makefile 'package/boot/kexec-tools/Makefile' has a dependency on 'liblzma', which does not exist
    WARNING: Makefile 'package/network/services/lldpd/Makefile' has a dependency on 'libnetsnmp', which does not exist
    WARNING: Makefile 'package/utils/policycoreutils/Makefile' has a dependency on 'libpam', which does not exist
    WARNING: Makefile 'package/utils/policycoreutils/Makefile' has a dependency on 'libpam', which does not exist
    WARNING: Makefile 'package/utils/policycoreutils/Makefile' has a build dependency on 'libpam', which does not exist

cpio:

    ( cd [...]/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/root-mediatek; find . | cpio -o -H newc -R root:root > [...]/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/linux-mediatek_mt7623/initrd.cpio )
    bash: cpio: command not found